### PR TITLE
Ease version constraints and fix test/helper.rb

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,12 +1,18 @@
 source "http://rubygems.org"
 
-gem "sexp_processor", "3.0.4"
-gem "ParseTree", "3.0.5"
-gem "RubyInline", "3.7.0"
-gem "hoe", "2.6.0"
-gem "minitest", "1.5.0"
-gem "rake", "0.8.7"
-gem "ruby_parser", "2.0.4"
-gem "rubyforge", "2.0.3"
-gem "colored", "1.2"
+gem "sexp_processor", ">= 3.0.4"
+gem "ParseTree", ">= 3.0.5"
+gem "RubyInline", ">= 3.7.0"
+gem "ruby_parser", ">= 2.0.4"
+gem "colored", ">= 1.2"
+
+group :test do
+  gem "minitest", ">= 1.5.0"
+end
+
+group :development do
+  gem "hoe", ">= 2.6.0"
+  gem "rake", ">= 0.8.7"
+  gem "rubyforge", ">= 2.0.3"
+end
 

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -5,7 +5,7 @@ require 'test/fixtures/multiplex'
 require 'tomdoc'
 
 module TomDoc
-  class Test < Test::Unit::TestCase
+  class Test < ::Test::Unit::TestCase
     def self.test(name, &block)
       define_method("test_#{name.gsub(/\W/,'_')}", &block) if block
     end

--- a/tomdoc.gemspec
+++ b/tomdoc.gemspec
@@ -17,10 +17,10 @@ Gem::Specification.new do |s|
   s.files            += Dir.glob("test/**/*")
   s.executables       = %w( tomdoc )
 
-  s.add_dependency "sexp_processor", "= 3.0.4"
-  s.add_dependency      "ParseTree", "= 3.0.5"
-  s.add_dependency     "RubyInline", "= 3.7.0"
-  s.add_dependency    "ruby_parser", "= 2.0.4"
+  s.add_dependency "sexp_processor", ">= 3.0.4"
+  s.add_dependency      "ParseTree", ">= 3.0.5"
+  s.add_dependency     "RubyInline", ">= 3.7.0"
+  s.add_dependency    "ruby_parser", ">= 2.0.4"
 
   s.description       = <<desc
   TomDoc is flexible code documentation with human readers in


### PR DESCRIPTION
Hi--

I grouped and eased the version constraints in the Gemfile and gemspec. This was preventing the use of Tomdoc with newer versions if RubyInline.

I also fixed an issue with the test helper whereby the Test::Unit wasn't being found.
