### PR TITLE
cache output of sections to save splitting every time

### DIFF
--- a/lib/tomdoc/tomdoc.rb
+++ b/lib/tomdoc/tomdoc.rb
@@ -57,7 +57,7 @@ module TomDoc
         raise InvalidTomDoc.new("No `Returns' statement.")
       end
 
-      if tomdoc.split("\n\n").size < 2
+      if sections.size < 2
         raise InvalidTomDoc.new("No description section found.")
       end
 
@@ -73,7 +73,7 @@ module TomDoc
     end
 
     def sections
-      tomdoc.split("\n\n")
+      @sections ||= tomdoc.split("\n\n")
     end
 
     def description


### PR DESCRIPTION
`sections` is referred to 4 or 5 times, in which it splits the raw tomdoc by `\n\n` every time. If we store this value we don't have to split it _every_ time
