### PR TITLE
Fix bug that made all comments invalid

### DIFF
--- a/lib/tomdoc/tomdoc.rb
+++ b/lib/tomdoc/tomdoc.rb
@@ -73,7 +73,7 @@ module TomDoc
     end
 
     def sections
-      @sections ||= tomdoc.split("\n\n")
+      @sections ||= raw.split("\n\n")
     end
 
     def description


### PR DESCRIPTION
Since `tomdoc` was normalized, there would never be two consecutive newlines in a row.
