### PR TITLE
Don't blow up horribly with ruby 1.9

### DIFF
--- a/lib/tomdoc/source_parser.rb
+++ b/lib/tomdoc/source_parser.rb
@@ -20,7 +20,7 @@ module TomDoc
     # Returns an instance of TomDoc::SourceParser
     def initialize(options = {})
       @options = {}
-      @parser  = RubyParser.new
+      @parser  = Ruby19Parser.new
       @scopes  = {}
     end
 

--- a/tomdoc.gemspec
+++ b/tomdoc.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.files            += Dir.glob("test/**/*")
   s.executables       = %w( tomdoc )
 
-  s.add_dependency   "ruby_parser",    ">= 2.0.4"
+  s.add_dependency   "ruby_parser",    ">= 3.0.0.a1"
   s.add_dependency   "colored"
 
   s.description       = <<desc


### PR DESCRIPTION
O HAI

Now that there's a (prerelease) version of RubyParser that supports 1.9, can we get a prerelease of tomdoc 0.2.6 or something that includes this? :D
