### PR TITLE
Upgrade ruby_parser to 3.0 API to support Ruby 1.9 etc.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source "http://rubygems.org"
 
-gem "ruby_parser", ">= 2.0.4"
+gem "ruby_parser", ">= 3.0.0"
 gem "colored", ">= 1.2"
 
 group :test do

--- a/lib/tomdoc/source_parser.rb
+++ b/lib/tomdoc/source_parser.rb
@@ -122,10 +122,10 @@ module TomDoc
       case Array(node)[0]
       when :module
         name = node[1]
-        [ :module, name, node.comments, tokenize(node[2]) ]
+        [ :module, name, node.comments, tokenize(node[2..-1]) ]
       when :class
         name = node[1]
-        [ :class, name, node.comments, tokenize(node[3]) ]
+        [ :class, name, node.comments, tokenize(node[3..-1]) ]
       when :defn
         name = node[1]
         args = args_for_node(node[2])

--- a/test/fixtures/chimney.rb
+++ b/test/fixtures/chimney.rb
@@ -660,8 +660,10 @@ module GitHub
         svc = smoke(host)
         exist =
           case type
-          when :user: svc.user_dir_exist?(name)
-          when :gist: svc.gist_dir_exist?(name)
+          when :user
+            svc.user_dir_exist?(name)
+          when :gist
+            svc.gist_dir_exist?(name)
           else false
           end
 


### PR DESCRIPTION
ruby_parser 3.0 eliminated `:scope` nodes and flattens the definitions under classes etc.

See 3.0.0.a1 log at https://github.com/seattlerb/ruby_parser/blob/master/History.txt

This will make tomdoc handle Ruby 1.9 source code.
