### PR TITLE
Handle empty TomDoc comment as an empty string

### DIFF
--- a/lib/tomdoc/tomdoc.rb
+++ b/lib/tomdoc/tomdoc.rb
@@ -126,7 +126,9 @@ module TomDoc
       end
 
       # put first line back
-      lines.unshift(first.sub(/^\s*/,''))
+      unless first.nil?
+        lines.unshift(first.sub(/^\s*/,''))
+      end
 
       lines.compact.join("\n")
     end

--- a/test/tomdoc_parser_test.rb
+++ b/test/tomdoc_parser_test.rb
@@ -71,6 +71,8 @@ comment4
     field - A field name.
 comment5
 
+    @comment6 = TomDoc::TomDoc.new('')
+
   end
 
   test "knows when TomDoc is invalid" do
@@ -170,5 +172,10 @@ comment5
   test "can hande comments without comment marker" do
     assert_equal "Duplicate some text an abitrary number of times.",
       @comment5.description
+  end
+
+  test "does not throw errors with an empty comment" do
+    assert_equal '', @comment6.raw
+    assert_equal '', @comment6.tomdoc
   end
 end


### PR DESCRIPTION
When you call `.tomdoc` on a method without any TomDoc documentation, the method will throw errors:

```
NoMethodError: undefined method `sub' for nil:NilClass
   .../tomdoc/lib/tomdoc/tomdoc.rb:130:in `tomdoc'
```

You can work around by calling `.valid?` before calling it, but other method such as `raw` works fine, and the error message isn't useful anyway.

This patch fixes it by simply returning '' for `comment.tomdoc` in case of no comments.
