### PR TITLE
Keep indent level in examples

### DIFF
--- a/lib/tomdoc/tomdoc.rb
+++ b/lib/tomdoc/tomdoc.rb
@@ -126,7 +126,9 @@ module TomDoc
       end
 
       # put first line back
-      lines.unshift(first.sub(/^\s*/,''))
+      unless first.nil?
+        lines.unshift(first.sub(/^\s*/,''))
+      end
 
       lines.compact.join("\n")
     end

--- a/lib/tomdoc/tomdoc.rb
+++ b/lib/tomdoc/tomdoc.rb
@@ -99,7 +99,7 @@ module TomDoc
       lines = raw.split("\n")
 
       # remove remark symbol
-      if lines.all?{ |line| /^\s*#/ =~ line }   
+      if lines.all?{ |line| /^\s*#/ =~ line }
         lines = lines.map do |line|
           line =~ /^(\s*#)/ ? line.sub($1, '') : nil
         end
@@ -109,21 +109,7 @@ module TomDoc
       # regardless, so we temporary remove it
       first = lines.shift
 
-      # remove indention
-      spaces = lines.map do |line|
-        next if line.strip.empty?
-        md = /^(\s*)/.match(line)
-        md ? md[1].size : nil
-      end.compact
-
-      space = spaces.min || 0
-      lines = lines.map do |line|
-        if line.empty?
-          line.strip
-        else
-          line[space..-1]
-        end
-      end
+      lines = deindent(lines)
 
       # put first line back
       unless first.nil?
@@ -244,6 +230,24 @@ module TomDoc
 
   private
 
+    def deindent(lines)
+      # remove indention
+      spaces = lines.map do |line|
+        next if line.strip.empty?
+        md = /^(\s*)/.match(line)
+        md ? md[1].size : nil
+      end.compact
+
+      space = spaces.min || 0
+      lines.map do |line|
+        if line.empty?
+          line.strip
+        else
+          line[space..-1]
+        end
+      end
+    end
+
     # Has the comment been parsed yet?
     def parsed(&block)
       parse unless @parsed
@@ -339,7 +343,8 @@ module TomDoc
 
       examples << section unless section.empty?
       while sections.first && sections.first !~ /^\S/
-        examples << sections.shift.strip
+        lines = sections.shift.split("\n")
+        examples << deindent(lines).join("\n")
       end
 
       @examples = examples

--- a/test/tomdoc_parser_test.rb
+++ b/test/tomdoc_parser_test.rb
@@ -119,7 +119,7 @@ comment5
   end
 
   test "knows each example" do
-    assert_equal "multiplex('Bo', 2)\n  # => 'BoBo'",
+    assert_equal "multiplex('Bo', 2)\n# => 'BoBo'",
       @comment.examples[1].to_s
   end
 

--- a/test/tomdoc_parser_test.rb
+++ b/test/tomdoc_parser_test.rb
@@ -71,6 +71,8 @@ comment4
     field - A field name.
 comment5
 
+    @comment6 = TomDoc::TomDoc.new('')
+
   end
 
   test "knows when TomDoc is invalid" do
@@ -170,5 +172,10 @@ comment5
   test "can hande comments without comment marker" do
     assert_equal "Duplicate some text an abitrary number of times.",
       @comment5.description
+  end
+
+  test "does not throw errors with an empty comment" do
+    assert_equal '', @comment6.raw
+    assert_equal '', @comment6.tomdoc
   end
 end


### PR DESCRIPTION
If you have a tomdoc like:

```
Examples

  def foo
    'bar'
  end
```

`tomdoc.examples[0]` would become

```
"def foo\n    'bar'\n  end"
```

which has a different level of indentation for the 1st line and the rest of the code.

This patch addresses the issue by reuseing the indent removal code in #tomdoc and strips the prefixed indent for each line and then recombine, so that the result will have the same indent leval you can run through as a code snippet.
